### PR TITLE
Viewly seed sale contract

### DIFF
--- a/contracts/ViewlySeedSale.sol
+++ b/contracts/ViewlySeedSale.sol
@@ -1,0 +1,144 @@
+// The MIT License (MIT)
+// Copyright (c) 2017 Viewly (https://view.ly)
+
+pragma solidity ^0.4.16;
+
+import "./lib/math.sol";
+import "./lib/token.sol";
+import "./lib/auth.sol";
+
+// Viewly seed token sale contract
+contract ViewlySeedSale is DSAuth, DSMath {
+
+    uint constant public ethCap   =         4000 ether;   // ether hard-cap
+    uint constant public tokenCap = 10 * 1000000 ether;   // token hard-cap
+
+    DSToken public VIEW;              // VIEW token contract
+    address public beneficiary;       // destination to collect eth deposits
+    uint public startBlock;           // start block of sale
+    uint public endBlock;             // end block of sale
+
+    uint public totalEthDeposited;    // sums of ether raised
+    uint public totalTokensBought;    // total tokens issued on sale
+    uint public totalEthCollected;    // total eth collected from sale
+
+    // buyers ether deposits
+    mapping (address => uint) public ethDeposits;
+
+    enum State {
+        Pending,
+        Running,
+        Ended
+    }
+    State public state = State.Pending;
+
+    event LogBuy(
+        address buyer,
+        uint ethDeposit,
+        uint tokensBought
+    );
+
+    event LogStartSale(
+        uint startBlock,
+        uint endBlock
+    );
+
+    event LogEndSale(
+        uint totalEthDeposited,
+        uint totalTokensBought
+    );
+
+    modifier salePending() { require(state == State.Pending); _; }
+    modifier saleRunning() { require(state == State.Running); _; }
+    modifier saleEnded() { require(state == State.Ended); _; }
+
+    // check current block is inside closed interval [startBlock, endBlock]
+    modifier inRunningBlock() {
+      require(block.number >= startBlock);
+      require(block.number < endBlock);
+      _;
+    }
+    // check sender has sent some ethers
+    modifier ethSent() { require(msg.value > 0); _; }
+
+
+    function ViewlySeedSale(DSToken _view, address _beneficiary) {
+        VIEW = _view;
+        beneficiary = _beneficiary;
+    }
+
+    // AUTHORIZATION REQUIRED //
+
+    function startSale(
+      uint _duration,
+      uint _blockOffset
+    ) auth salePending {
+        require(_duration > 0);
+        require(_blockOffset >= 0);
+
+        startBlock = add(block.number, _blockOffset);
+        endBlock   = add(startBlock, _duration);
+        state      = State.Running;
+
+        LogStartSale(startBlock, endBlock);
+    }
+
+    function endSale() auth saleRunning {
+      state = State.Ended;
+
+      LogEndSale(totalEthDeposited, totalTokensBought);
+    }
+
+    function extendSale(uint _blocks) auth saleRunning {
+      require(_blocks > 0);
+
+      endBlock += add(endBlock, _blocks);
+    }
+
+    // deposited ethers can be collected any time
+    function collectEth() auth {
+      require(this.balance > 0);
+
+      totalEthCollected = add(totalEthCollected, this.balance);
+      beneficiary.transfer(this.balance);
+    }
+
+
+    // PUBLIC FUNCTIONS //
+
+    function totalEthRaised() returns(uint) {
+      return add(this.balance, totalEthCollected);
+    }
+
+    function buyTokens() saleRunning inRunningBlock ethSent payable {
+      // update deposits and tokens bought
+      ethDeposits[msg.sender] = add(msg.value, ethDeposits[msg.sender]);
+      totalEthDeposited = add(msg.value, totalEthDeposited);
+      uint128 tokensBought = calculateTokensFor(msg.value);
+      totalTokensBought = add(tokensBought, totalTokensBought);
+
+      // check caps are respected
+      require(totalEthDeposited <= ethCap);
+      require(totalTokensBought <= tokenCap);
+
+      // return tokens
+      VIEW.mint(tokensBought);
+      VIEW.transfer(msg.sender, tokensBought);
+
+      LogBuy(msg.sender, msg.value, tokensBought);
+    }
+
+    function () payable {
+      buyTokens();
+    }
+
+
+    // PRIVATE FUNCTIONS //
+
+    function calculateTokensFor(uint ethSent)
+    private constant returns(uint128 tokens)
+    {
+      // ethSent / ethCap * tokenCap
+      return cast(div(mul(ethSent, tokenCap), ethCap));
+    }
+}

--- a/deploy.py
+++ b/deploy.py
@@ -33,17 +33,17 @@ def main():
         check_succesful_tx(web3, tx)
         print('ViewToken has authorithy set')
 
-        print('Deploying ViewlySale')
-        multisig_address = sys.argv[2]
-        sale = deploy_contract(chain, owner, 'ViewlySale', [view_token.address, multisig_address])
-        print('ViewlySale address is', sale.address)
+        print('Deploying ViewlySeedSale')
+        beneficiary = sys.argv[2]
+        sale = deploy_contract(chain, owner, 'ViewlySeedSale', [view_token.address, beneficiary])
+        print('ViewlySeedSale address is', sale.address)
         authority_permit_any(chain, view_auth, sale.address, view_token.address)
-        print('ViewlySale is permitted to use ViewToken')
+        print('ViewlySeedSale is permitted to use ViewToken')
 
         print('Writing ABIs to ./build')
         dump_abi(view_auth, 'build/view_auth_abi.json')
         dump_abi(view_token, 'build/view_token_abi.json')
-        dump_abi(sale, 'build/viewly_sale_abi.json')
+        dump_abi(sale, 'build/viewly_seed_sale_abi.json')
 
         print('All done!')
 

--- a/tests/test_viewly_seed_sale.py
+++ b/tests/test_viewly_seed_sale.py
@@ -1,0 +1,160 @@
+import pytest
+
+from web3.contract import Contract
+from eth_utils import to_wei
+
+from ethereum.tester import TransactionFailed
+from populus.chain.base import BaseChain
+
+
+TOKEN_CAP       = to_wei(10000000, 'ether')
+ETH_CAP         = to_wei(4000, 'ether')
+DURATION        = 10
+BLOCK_OFFSET    = 2
+
+def deploy_contract(chain: BaseChain, contract_name: str, args=[]) -> Contract:
+    # deploy contract on chain with coinbase and optional init args
+    factory = chain.get_contract_factory(contract_name)
+    deploy_tx_hash = factory.deploy(args=args)
+    contract_address = chain.wait.for_contract_address(deploy_tx_hash)
+    return factory(address=contract_address)
+
+def send_eth_to_sale(chain, sale, user, eth_to_send):
+    return chain.web3.eth.sendTransaction({
+        'from': user,
+        'to': sale.address,
+        'value': eth_to_send,
+        'gas': 250000,
+    })
+
+@pytest.fixture()
+def token(chain: BaseChain) -> Contract:
+    """ A VIEW token contract. """
+    return deploy_contract(chain, 'DSToken', args=['VIEW'])
+
+@pytest.fixture()
+def sale(chain: BaseChain, token: Contract, beneficiary) -> Contract:
+    """ A blank ViewlySeedSale contract. """
+    args = [token.address, beneficiary]
+    seed_sale = deploy_contract(chain, 'ViewlySeedSale', args=args)
+    token.transact().setOwner(seed_sale.address)
+    return seed_sale
+
+@pytest.fixture()
+def running_sale(chain: BaseChain, token: Contract, sale) -> Contract:
+    """ A running ViewlySeedSale contract. """
+    sale.transact().startSale(DURATION, BLOCK_OFFSET)
+    chain.wait.for_block(sale.call().startBlock())
+    return sale
+
+@pytest.fixture
+def owner(accounts) -> str:
+    return accounts[0]
+
+@pytest.fixture
+def customer(accounts) -> str:
+    return accounts[1]
+
+@pytest.fixture
+def customer2(accounts) -> str:
+    return accounts[2]
+
+@pytest.fixture
+def beneficiary(accounts) -> str:
+    return accounts[3]
+
+
+# --------
+# TESTS
+# --------
+
+def test_init(chain, token, beneficiary):
+    sale = deploy_contract(chain, 'ViewlySeedSale',
+            args=[token.address, beneficiary])
+
+    assert sale.call().VIEW() == token.address
+
+def test_start_sale(web3, sale):
+    sale.transact().startSale(DURATION, BLOCK_OFFSET)
+    expected_start_block = web3.eth.blockNumber + BLOCK_OFFSET
+    expected_end_block = web3.eth.blockNumber + BLOCK_OFFSET + DURATION
+
+    assert sale.call().state() == 1
+    assert sale.call().ethCap() == ETH_CAP
+    assert sale.call().tokenCap() == TOKEN_CAP
+    assert sale.call().startBlock() == expected_start_block
+    assert sale.call().endBlock() == expected_end_block
+
+    start_event = sale.pastEvents('LogStartSale').get()[0]['args']
+    assert start_event['startBlock'] == expected_start_block
+    assert start_event['endBlock'] == expected_end_block
+
+def test_end_sale(chain: BaseChain, running_sale, customer, beneficiary):
+    sale = running_sale
+
+    # buy some token on sale
+    eth_sent = to_wei(2000, 'ether')
+    send_eth_to_sale(chain, sale, customer, eth_sent)
+
+    # ending sale before end block should be possible
+    sale.transact().endSale()
+
+    assert sale.call().state() == 2
+    end_event = sale.pastEvents('LogEndSale').get()[0]['args']
+    assert end_event['totalEthDeposited'] == eth_sent
+    assert end_event['totalTokensBought'] == TOKEN_CAP // 2
+
+def test_collect_eth_and_total_eth_raised(chain: BaseChain, running_sale, customer, beneficiary):
+    sale = running_sale
+
+    # buy some token on sale
+    send_eth_to_sale(chain, sale, customer, to_wei(10, 'ether'))
+
+    # collect deposited eth before end of sale
+    start_balance = chain.web3.eth.getBalance(beneficiary)
+    sale.transact().collectEth()
+    end_balance = chain.web3.eth.getBalance(beneficiary)
+    assert (end_balance - start_balance) == to_wei(10, 'ether')
+    assert chain.web3.eth.getBalance(sale.address) == 0
+
+    # buy some more
+    send_eth_to_sale(chain, sale, customer, to_wei(30, 'ether'))
+    assert chain.web3.eth.getBalance(sale.address) == to_wei(30, 'ether')
+    assert sale.call().totalEthRaised() == to_wei(40, 'ether')
+
+def test_buy(chain, web3, token, sale, customer):
+    sale.transact().startSale(DURATION, 0)
+
+    eth_sent = to_wei(40, 'ether')
+    send_eth_to_sale(chain, sale, customer, eth_sent)
+    expected_tokens = TOKEN_CAP * eth_sent // ETH_CAP;
+
+    # sale contract should save eth deposit and update totals
+    assert sale.call().ethDeposits(customer) == eth_sent
+    assert web3.eth.getBalance(sale.address) == eth_sent
+    assert sale.call().totalEthDeposited() == eth_sent
+
+    # token supply should increase
+    assert token.call().totalSupply() == expected_tokens
+
+    # customer should receive expected tokens
+    assert token.call().balanceOf(customer) == expected_tokens
+
+    # check event was logged correctly
+    buy_event = sale.pastEvents('LogBuy').get()[0]['args']
+    assert buy_event['buyer'] == customer
+    assert buy_event['ethDeposit'] == eth_sent
+    assert buy_event['tokensBought'] == expected_tokens
+
+def test_extend_sale(chain: BaseChain, token, running_sale, customer):
+    sale = running_sale
+
+    # buying something on end block should not succeed
+    chain.wait.for_block(sale.call().endBlock())
+    with pytest.raises(TransactionFailed):
+        send_eth_to_sale(chain, sale, customer, to_wei(1, 'ether'))
+
+    # extend sale for 2 more blocks and re-try
+    sale.transact().extendSale(2)
+    send_eth_to_sale(chain, sale, customer, to_wei(1, 'ether'))
+    assert token.call().balanceOf(customer) > 0


### PR DESCRIPTION
Implement basic token sale contract with the following features:
* hard-coded eth and token hard caps
* VIEW and beneficiary addresses are injected deploy-time
* duration and offset block are set when startSale is called
* sale can be extended anytime when sale is in progress
* sale can be ended preliminary
* eth can be collected any-time and multiple times during the sale
* there's a public function which tracks total raised eth (including
  stuff already collected)
* tokens are bought at a fixed price and are sent to the buyer right
  away, in the same transaction when they send ethers