### PR TITLE
Linear token bonus and some style improvements

### DIFF
--- a/tests/test_viewly_seed_sale.py
+++ b/tests/test_viewly_seed_sale.py
@@ -79,7 +79,7 @@ def beneficiary(accounts) -> str:
 def test_init(chain, token, beneficiary):
     sale = deploy_contract(chain, 'ViewlySeedSale', args=[token.address, beneficiary])
 
-    assert sale.call().VIEW() == token.address
+    assert sale.call().viewToken() == token.address
     assert sale.call().beneficiary() == beneficiary
 
 def test_start_sale(web3, sale):
@@ -88,8 +88,8 @@ def test_start_sale(web3, sale):
     expected_end_block = web3.eth.blockNumber + BLOCK_OFFSET + DURATION
 
     assert sale.call().state() == 1
-    assert sale.call().ethCap() == ETH_CAP
-    assert sale.call().tokenCap() == TOKEN_CAP
+    assert sale.call().ETH_CAP() == ETH_CAP
+    assert sale.call().TOKEN_CAP() == TOKEN_CAP
     assert sale.call().startBlock() == expected_start_block
     assert sale.call().endBlock() == expected_end_block
 


### PR DESCRIPTION
Amount of VIEW tokens send back to buyers decreases linearly: early buyers get bonus tokens over last buyer. Bonus is maximal at the beginning (15%) and gradually lowers as deposits are sent in. It is
finally reduced to zero as eth cap is reached. Token bonus also applies inside a single purchase: even the first buyer gets lower average bonus if sends in more ethers. If first buyer sends in 4000 eth (eth cap), his average bonus will be half of max bonus, because his purchase spans from
max bonus to 0 bonus.