### PR TITLE
Rename category Founders => Team

### DIFF
--- a/contracts/view_token_mintage.sol
+++ b/contracts/view_token_mintage.sol
@@ -15,7 +15,7 @@ import "./dappsys/auth.sol";
 contract ViewTokenMintage is DSAuth, DSMath {
 
     enum CategoryId {
-        Founders,
+        Team,
         Supporters,
         Creators,
         Bounties,
@@ -41,7 +41,7 @@ contract ViewTokenMintage is DSAuth, DSMath {
         viewToken = viewToken_;
 
         uint MILLION = 1000000 ether;
-        categories[uint8(CategoryId.Founders)]   = Category(18 * MILLION, 0 ether);
+        categories[uint8(CategoryId.Team)]       = Category(18 * MILLION, 0 ether);
         categories[uint8(CategoryId.Supporters)] = Category(9 * MILLION, 0 ether);
         categories[uint8(CategoryId.Creators)]   = Category(20 * MILLION, 0 ether);
         categories[uint8(CategoryId.Bounties)]   = Category(3 * MILLION, 113528 ether);

--- a/scripts/distribute.py
+++ b/scripts/distribute.py
@@ -23,7 +23,7 @@ from db import (
     mark_tx_for_retry,
 )
 
-roles = 'Founders Supporters Creators Bounties SeedSale MainSale'.split(' ')
+roles = 'Team Supporters Creators Bounties SeedSale MainSale'.split(' ')
 buckets = dict(zip(roles, range(len(roles))))
 
 def rename_field(field_name):
@@ -48,11 +48,7 @@ def validated_payouts(payouts_in):
     """
     # swap bucket name with matching ID
     payouts = [
-        {
-            **x,
-            'bucket': buckets[x['bucket'].lower().title()],
-            'amount': float(x['amount'].replace(',', '')),
-        }
+        {**x, 'bucket': buckets[x['bucket'].lower().title()]}
         for x in (keymap(rename_field, y) for y in payouts_in)
     ]
 
@@ -104,7 +100,7 @@ def mint_tokens(
         owner: An authorized Ethereum account to call the minting contract from.
         recipient: Address of VIEW Token Recipient.
         amount: Amount of VIEW Tokens to mint.
-        bucket: A bucket number of the funding source (Founders, Supporters...)
+        bucket: A bucket number of the funding source (Team, Supporters...)
 
     Returns:
         txid: Transaction ID of the function call
@@ -225,12 +221,7 @@ def cli_verify(chain_provider, chain_name, db_file):
      WHERE success = 0 AND txid IS NOT NULL;
     """
     for id_, txid in query_all(db_file, q):
-        try:
-            success = is_tx_successful(w3, txid)
-        except:
-            print(f'Unable to verify {txid}. Try again later.')
-            continue
-        if success:
+        if is_tx_successful(w3, txid):
             mark_tx_as_successful(db_file, id_)
             print(f'{txid} is OK.')
         else:

--- a/tests/test_view_token_mintage.py
+++ b/tests/test_view_token_mintage.py
@@ -10,7 +10,7 @@ from helpers import deploy_contract
 contract_name = 'ViewTokenMintage'
 
 class CategoryId:
-    Founders   = 0
+    Team       = 0
     Supporters = 1
     Creators   = 2
     Bounties   = 3
@@ -53,7 +53,7 @@ def test_init(chain, instance, token):
 
     category = lambda category: instance.call().categories(category)
     million = 1_000_000
-    assert category(CategoryId.Founders)[0] == to_wei(18 * million, 'ether')
+    assert category(CategoryId.Team)[0] == to_wei(18 * million, 'ether')
     assert category(CategoryId.Supporters)[0] == to_wei(9 * million, 'ether')
     assert category(CategoryId.Creators)[0] == to_wei(20 * million, 'ether')
     assert category(CategoryId.Bounties)[0] == to_wei(3 * million, 'ether')
@@ -64,33 +64,33 @@ def test_init(chain, instance, token):
 def test_mint(chain, instance, token, recipient, recipient2):
     category = lambda category: instance.call().categories(category)
 
-    instance.transact().mint(recipient, to_wei(1, 'ether'), CategoryId.Founders)
+    instance.transact().mint(recipient, to_wei(1, 'ether'), CategoryId.Team)
     assert_last_tokens_minted(instance, recipient, to_wei(1, 'ether'))
     assert token.call().balanceOf(recipient) == to_wei(1, 'ether')
-    assert category(CategoryId.Founders)[1] == to_wei(1, 'ether')
+    assert category(CategoryId.Team)[1] == to_wei(1, 'ether')
 
-    instance.transact().mint(recipient, to_wei(9, 'ether'), CategoryId.Founders)
+    instance.transact().mint(recipient, to_wei(9, 'ether'), CategoryId.Team)
     assert_last_tokens_minted(instance, recipient, to_wei(9, 'ether'))
     assert token.call().balanceOf(recipient) == to_wei(10, 'ether')
-    assert category(CategoryId.Founders)[1] == to_wei(10, 'ether')
+    assert category(CategoryId.Team)[1] == to_wei(10, 'ether')
 
     instance.transact().mint(recipient2, to_wei(90, 'ether'), CategoryId.Supporters)
     assert_last_tokens_minted(instance, recipient2, to_wei(90, 'ether'))
     assert token.call().balanceOf(recipient2) == to_wei(90, 'ether')
-    assert category(CategoryId.Founders)[1] == to_wei(10, 'ether')
+    assert category(CategoryId.Team)[1] == to_wei(10, 'ether')
     assert category(CategoryId.Supporters)[1] == to_wei(90, 'ether')
 
 
 def test_mint_fails_after_cap_reached(chain, instance, token, recipient):
     category = lambda category: instance.call().categories(category)
 
-    founders_mint_max = category(CategoryId.Founders)[0]
-    instance.transact().mint(recipient, founders_mint_max, CategoryId.Founders)
-    assert category(CategoryId.Founders)[1] == founders_mint_max
+    team_mint_max = category(CategoryId.Team)[0]
+    instance.transact().mint(recipient, team_mint_max, CategoryId.Team)
+    assert category(CategoryId.Team)[1] == team_mint_max
 
     # rewards cannot be distributed any more after cap is reached
     with pytest.raises(TransactionFailed):
-        instance.transact().mint(recipient, 1, CategoryId.Founders)
+        instance.transact().mint(recipient, 1, CategoryId.Team)
 
 def test_mint_fails_when_category_invalid(chain, instance, token, recipient):
     invalid_category = 6
@@ -101,15 +101,15 @@ def test_mint_fails_when_not_authorized(chain, instance, token, recipient):
     # sendTokenReward cannot be called by a random user
     with pytest.raises(TransactionFailed):
         instance.transact(
-            {"from": recipient}).mint(recipient, 1, CategoryId.Founders)
+            {"from": recipient}).mint(recipient, 1, CategoryId.Team)
 
 def test_destruct(chain, instance, token, owner):
-    instance.transact().mint(owner, 1, CategoryId.Founders)
+    instance.transact().mint(owner, 1, CategoryId.Team)
     instance.transact().destruct(owner)
 
     # minting doesn't work after contract is destructed
     with pytest.raises(Exception):
-        instance.transact().mint(recipient, 1, CategoryId.Founders)
+        instance.transact().mint(recipient, 1, CategoryId.Team)
 
 def test_total_mint_limit(chain, instance):
     assert instance.call().totalMintLimit() == to_wei(100_000_000, 'ether')


### PR DESCRIPTION
In WP, we refer it as Founder and Team. Because all founders are part of team, but not all team members are founders, it is better to name it Team. (Otherwise it can be confusing inside token payout sheets).