### PR TITLE
Replace token mint with transferFrom call

### DIFF
--- a/contracts/view_token_mintage.sol
+++ b/contracts/view_token_mintage.sol
@@ -58,7 +58,8 @@ contract ViewTokenMintage is DSAuth, DSMath {
         require(add(tokens, category.amountMinted) <= category.mintLimit);
 
         categories[uint8(categoryId)].amountMinted += tokens;
-        viewToken.mint(recipient, tokens);
+        viewToken.mint(this, tokens);
+        viewToken.transferFrom(this, recipient, tokens);
         TokensMinted(recipient, tokens, categoryId);
     }
 


### PR DESCRIPTION
This increases gas by 60%, but makes the transaction that is detectable
by etherscan automatically - meaning less hassle for people to tokens in
their wallets.