### PR TITLE
Fix category name handling on import-txs script

### DIFF
--- a/scripts/distribute.py
+++ b/scripts/distribute.py
@@ -50,7 +50,7 @@ def validated_payouts(payouts_in):
     payouts = [
         {
             **x,
-            'bucket': buckets[x['bucket'].lower().title()],
+            'bucket': buckets[x['bucket']],
             'amount': float(x['amount'].replace(',', '')),
         }
         for x in (keymap(rename_field, y) for y in payouts_in)


### PR DESCRIPTION
The distribute/import-txs script didn't properly handle category name
when importing token transactions into the db. For some reason it
lowercased & titlelized the names. This conflicted with our camel case
notation of category names inside the categories list (in sync with
contract code), meaning it didn't work for SeedSale or MainSale
categories.

Therefore, remove these category name transformations. Just use what you
get in the csv file and pass it along.